### PR TITLE
Jimin/roommate chatroom checklist 8

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomApiSpecification.java
@@ -1,0 +1,80 @@
+package com.example.appcenter_project.controller.roommate;
+
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateChatRoomDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateCheckListDto;
+import com.example.appcenter_project.security.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+
+import java.util.List;
+
+@Tag(name = "RoommateChattingRoom", description = "룸메이트 채팅방 관련 API")
+public interface RoommateChattingRoomApiSpecification {
+
+    @Operation(
+            summary = "채팅방 생성",
+            description = "특정 룸메이트 게시글을 기반으로 채팅방을 생성합니다. (게스트가 요청)",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "채팅방 생성 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = Long.class))),
+                    @ApiResponse(responseCode = "404", description = "게시글 또는 유저를 찾을 수 없음"),
+                    @ApiResponse(responseCode = "400", description = "자기 자신과의 채팅 방지, 중복 생성 방지")
+            }
+    )
+    ResponseEntity<Long> createChatRoom(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            Long roommateBoardId
+    );
+
+    @Operation(
+            summary = "채팅방 나가기",
+            description = "게스트가 특정 채팅방에서 나가며 채팅방이 삭제됩니다.",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "나가기 성공 (채팅방 삭제)"),
+                    @ApiResponse(responseCode = "404", description = "유저 또는 채팅방을 찾을 수 없음"),
+                    @ApiResponse(responseCode = "403", description = "게스트가 아닌 사용자의 접근")
+            }
+    )
+    ResponseEntity<Void> leaveChatRoom(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            Long chatRoomId
+    );
+
+    @Operation(
+            summary = "채팅방 목록 조회",
+            description = "로그인한 사용자가 참여한 모든 채팅방 목록을 조회합니다. (마지막 메시지 기준 최신순)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseRoommateChatRoomDto.class))),
+                    @ApiResponse(responseCode = "404", description = "유저를 찾을 수 없음")
+            }
+    )
+    ResponseEntity<List<ResponseRoommateChatRoomDto>> getRoommateChatRoomList(
+            @Parameter(hidden = true) CustomUserDetails userDetails
+    );
+
+    @Operation(
+            summary = "상대방 체크리스트 조회",
+            description = "채팅방 ID를 통해 현재 로그인한 사용자의 상대방 체크리스트를 조회합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "조회 성공",
+                            content = @Content(mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseRoommateCheckListDto.class))),
+                    @ApiResponse(responseCode = "404", description = "채팅방이 존재하지 않음"),
+                    @ApiResponse(responseCode = "403", description = "해당 채팅방에 접근할 권한 없음")
+            }
+    )
+    ResponseEntity<ResponseRoommateCheckListDto> getOpponentChecklist(
+            @Parameter(hidden = true) CustomUserDetails user,
+            @Parameter(description = "채팅방 ID") Long chatRoomId
+    );
+
+
+}

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateChattingRoomController.java
@@ -1,0 +1,59 @@
+package com.example.appcenter_project.controller.roommate;
+
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateChatRoomDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateCheckListDto;
+import com.example.appcenter_project.entity.roommate.RoommateCheckList;
+import com.example.appcenter_project.security.CustomUserDetails;
+import com.example.appcenter_project.service.roommate.RoommateChattingRoomService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.CREATED;
+
+@RestController
+@RequestMapping("/roommate-chatting-room")
+@RequiredArgsConstructor
+public class RoommateChattingRoomController implements RoommateChattingRoomApiSpecification{
+
+    private final RoommateChattingRoomService roommateChattingRoomService;
+
+    // 게스트가 채팅방 참여 요청
+    @PostMapping("/board/{roommateBoardId}")
+    public ResponseEntity<Long> createChatRoom(@AuthenticationPrincipal CustomUserDetails user,
+                                               @PathVariable Long roommateBoardId) {
+        Long roomId = roommateChattingRoomService.createChatRoom(user.getId(), roommateBoardId);
+        return ResponseEntity.status(201).body(roomId);
+    }
+
+    // 채팅방 나가기 (게스트 기준)
+    @DeleteMapping("/{chatRoomId}")
+    public ResponseEntity<Void> leaveChatRoom(@AuthenticationPrincipal CustomUserDetails user,
+                                              @PathVariable Long chatRoomId) {
+        roommateChattingRoomService.leaveChatRoom(user.getId(), chatRoomId);
+        return ResponseEntity.status(CREATED).build();
+    }
+
+    // 채팅방 목록 조회
+    @GetMapping
+    public ResponseEntity<List<ResponseRoommateChatRoomDto>> getRoommateChatRoomList(
+            @AuthenticationPrincipal CustomUserDetails user) {
+        List<ResponseRoommateChatRoomDto> chatRooms = roommateChattingRoomService.findRoommateChatRoomListByUser(user);
+        return ResponseEntity.ok(chatRooms);
+    }
+
+    //상대방 체크리스트 확인
+    @GetMapping("/roommate-chatrooms/{chatRoomId}/opponent-checklist")
+    public ResponseEntity<ResponseRoommateCheckListDto> getOpponentChecklist(
+            @AuthenticationPrincipal CustomUserDetails user,
+            @PathVariable Long chatRoomId
+    ) {
+        RoommateCheckList checklist = roommateChattingRoomService.getOpponentChecklist(user.getId(), chatRoomId);
+        return ResponseEntity.ok(ResponseRoommateCheckListDto.from(checklist));
+    }
+
+
+}

--- a/src/main/java/com/example/appcenter_project/dto/request/roommate/RequestRoommateChatDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/request/roommate/RequestRoommateChatDto.java
@@ -1,0 +1,16 @@
+package com.example.appcenter_project.dto.request.roommate;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+public class RequestRoommateChatDto {
+
+    @NotNull
+    private Long roommateChattingRoomId;
+
+    @NotBlank
+    private String content;
+}
+

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatDto.java
@@ -1,0 +1,27 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import com.example.appcenter_project.entity.roommate.RoommateChattingChat;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@Builder
+public class ResponseRoommateChatDto {
+
+    private Long roommateChattingRoomId;
+    private Long roommateChatId;
+    private Long userId;
+    private String content;
+    private boolean read;
+
+    public static ResponseRoommateChatDto entityToDto(RoommateChattingChat chat) {
+        return ResponseRoommateChatDto.builder()
+                .roommateChattingRoomId(chat.getRoommateChattingRoom().getId())
+                .roommateChatId(chat.getId())
+                .userId(chat.getMember().getId())
+                .content(chat.getContent())
+                .read(chat.isReadByReceiver())
+                .build();
+    }
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateChatRoomDto.java
@@ -1,0 +1,15 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ResponseRoommateChatRoomDto {
+    private Long chatRoomId;
+    private String opponentNickname;
+    private String lastMessage;
+    private LocalDateTime lastMessageTime;
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateCheckListDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateCheckListDto.java
@@ -1,0 +1,49 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import com.example.appcenter_project.entity.roommate.RoommateCheckList;
+import com.example.appcenter_project.enums.roommate.*;
+import com.example.appcenter_project.enums.user.College;
+import com.example.appcenter_project.enums.user.DormType;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Set;
+
+@Getter
+@Builder
+public class ResponseRoommateCheckListDto {
+
+    private String title;
+    private Set<DormDay> dormPeriod;
+    private DormType dormType;
+    private College college;
+    private String mbti;
+    private SmokingType smoking;
+    private SnoringType snoring;
+    private TeethGrindingType toothGrind;
+    private SleepSensitivityType sleeper;
+    private ShowerTimeType showerHour;
+    private ShowerDurationType showerTime;
+    private BedTimeType bedTime;
+    private CleanlinessType arrangement;
+    private String comment;
+
+    public static ResponseRoommateCheckListDto from(RoommateCheckList checklist) {
+        return ResponseRoommateCheckListDto.builder()
+                .title(checklist.getTitle())
+                .dormPeriod(checklist.getDormPeriod())
+                .dormType(checklist.getDormType())
+                .college(checklist.getCollege())
+                .mbti(checklist.getMbti())
+                .smoking(checklist.getSmoking())
+                .snoring(checklist.getSnoring())
+                .toothGrind(checklist.getToothGrind())
+                .sleeper(checklist.getSleeper())
+                .showerHour(checklist.getShowerHour())
+                .showerTime(checklist.getShowerTime())
+                .bedTime(checklist.getBedTime())
+                .arrangement(checklist.getArrangement())
+                .comment(checklist.getComment())
+                .build();
+    }
+}

--- a/src/main/java/com/example/appcenter_project/entity/roommate/RoommateChattingChat.java
+++ b/src/main/java/com/example/appcenter_project/entity/roommate/RoommateChattingChat.java
@@ -1,0 +1,46 @@
+package com.example.appcenter_project.entity.roommate;
+
+import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RoommateChattingChat extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "roommate_chatting_room_id", nullable = false)
+    private RoommateChattingRoom roommateChattingRoom;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id", nullable = false)
+    private User member;
+
+    @Column(nullable = false, length = 1000)
+    private String content;
+
+    @Column(nullable = false)
+    private boolean readByReceiver = false; // 읽음 여부
+
+    @Builder
+    public RoommateChattingChat(RoommateChattingRoom roommateChattingRoom, User member, String content, boolean readByReceiver) {
+        this.roommateChattingRoom = roommateChattingRoom;
+        this.member = member;
+        this.content = content;
+        this.readByReceiver = readByReceiver;
+    }
+
+
+    public void markAsRead() {
+        this.readByReceiver = true;
+    }
+}
+

--- a/src/main/java/com/example/appcenter_project/entity/roommate/RoommateChattingRoom.java
+++ b/src/main/java/com/example/appcenter_project/entity/roommate/RoommateChattingRoom.java
@@ -1,0 +1,57 @@
+package com.example.appcenter_project.entity.roommate;
+
+import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class RoommateChattingRoom extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 채팅이 생성된 게시글
+    @ManyToOne
+    @JoinColumn(name = "roommate_board_id", nullable = false)
+    private RoommateBoard roommateBoard;
+
+    // 게시글 작성자 (고정, 모든 채팅방에 동일)
+    @ManyToOne
+    @JoinColumn(name = "guest_id", nullable = false)
+    private User guest;
+
+    // 채팅 요청자
+    @ManyToOne
+    @JoinColumn(name = "host_id", nullable = false)
+    private User host;
+
+    @OneToOne
+    @JoinColumn(name = "guest_roommate_checklist_id", nullable = false)
+    private RoommateCheckList guestChecklist;
+
+    @OneToOne
+    @JoinColumn(name = "host_roommate_checklist_id", nullable = false)
+    private RoommateCheckList hostChecklist;
+
+    @OneToMany(mappedBy = "roommateChattingRoom", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<RoommateChattingChat> chattingChatList = new ArrayList<>();
+
+    @Builder
+    public RoommateChattingRoom(RoommateBoard roommateBoard, User guest, User host,
+                                RoommateCheckList guestChecklist, RoommateCheckList hostChecklist) {
+        this.roommateBoard = roommateBoard;
+        this.guest = guest;
+        this.host = host;
+        this.guestChecklist = guestChecklist;
+        this.hostChecklist = hostChecklist;
+    }
+}

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -74,7 +74,14 @@ public enum ErrorCode {
     ROOMMATE_ALREADY_MATCHED(HttpStatus.CONFLICT,8105,"[RoommateMatching] 이미 매칭된 사람이 있습니다."),
 
     // ROOMMATE_MYROOMMATE
-    MY_ROOMMATE_NOT_REGISTERED(NOT_FOUND, 9201, "[MyRoommate] 해당 사용자의 룸메이트 정보를 찾을 수 없습니다"),;
+    MY_ROOMMATE_NOT_REGISTERED(NOT_FOUND, 9201, "[MyRoommate] 해당 사용자의 룸메이트 정보를 찾을 수 없습니다"),
+    RULE_NOT_FOUND(NOT_FOUND, 9203, "[MyRoommate] 수정할 규칙이 존재하지 않습니다."),
+
+    // ROOMMATE_CHAT
+    ROOMMATE_CHAT_CANNOT_CHAT_WITH_SELF(BAD_REQUEST, 10001, "[RoommateChat] 자신에게는 채팅을 보낼 수 없습니다."),
+    DUPLICATE_CHAT_ROOM(CONFLICT, 10001, "[RoommateChat] 이미 존재하는 채팅방입니다."),
+    ROOMMATE_CHAT_ROOM_NOT_FOUND(NOT_FOUND, 7013, "[RoommateChat] 채팅방을 찾을 수 없습니다."),
+    ROOMMATE_CHAT_ROOM_FORBIDDEN(FORBIDDEN, 10004, "[RoommateChat] 이 채팅방에 속하지 않은 사용자입니다.");
 
     private final HttpStatus httpStatus;
     private final Integer code;

--- a/src/main/java/com/example/appcenter_project/repository/roommate/RoommateChattingChatRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/RoommateChattingChatRepository.java
@@ -1,0 +1,17 @@
+package com.example.appcenter_project.repository.roommate;
+
+import com.example.appcenter_project.entity.roommate.RoommateChattingChat;
+import com.example.appcenter_project.entity.roommate.RoommateChattingRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoommateChattingChatRepository extends JpaRepository<RoommateChattingChat, Long> {
+    List<RoommateChattingChat> findAllByRoommateChattingRoom_Id(Long roomId);
+    List<RoommateChattingChat> findByRoommateChattingRoom(RoommateChattingRoom chatRoom);
+
+    List<RoommateChattingChat> findByRoommateChattingRoomAndReadByReceiverFalse(RoommateChattingRoom chatRoom);
+
+    List<RoommateChattingChat> findByRoommateChattingRoomAndMemberNotAndReadByReceiverFalse(RoommateChattingRoom chatRoom, com.example.appcenter_project.entity.user.User member);
+
+}

--- a/src/main/java/com/example/appcenter_project/repository/roommate/RoommateChattingRoomRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/RoommateChattingRoomRepository.java
@@ -1,0 +1,14 @@
+package com.example.appcenter_project.repository.roommate;
+
+import com.example.appcenter_project.entity.roommate.RoommateBoard;
+import com.example.appcenter_project.entity.roommate.RoommateChattingRoom;
+import com.example.appcenter_project.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface RoommateChattingRoomRepository extends JpaRepository<RoommateChattingRoom, Long> {
+    boolean existsByRoommateBoardAndGuest(RoommateBoard board, User guest);
+    List<RoommateChattingRoom> findAllByHostOrGuest(User host, User guest);
+}
+

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateChattingRoomService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateChattingRoomService.java
@@ -1,0 +1,157 @@
+package com.example.appcenter_project.service.roommate;
+
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateChatRoomDto;
+import com.example.appcenter_project.entity.roommate.RoommateBoard;
+import com.example.appcenter_project.entity.roommate.RoommateChattingChat;
+import com.example.appcenter_project.entity.roommate.RoommateChattingRoom;
+import com.example.appcenter_project.entity.roommate.RoommateCheckList;
+import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.exception.CustomException;
+import com.example.appcenter_project.repository.roommate.RoommateBoardRepository;
+import com.example.appcenter_project.repository.roommate.RoommateChattingRoomRepository;
+import com.example.appcenter_project.repository.roommate.RoommateCheckListRepository;
+import com.example.appcenter_project.repository.user.UserRepository;
+import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.security.CustomUserDetails;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import java.util.ArrayList;
+
+import java.time.LocalDateTime;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+import static com.example.appcenter_project.exception.ErrorCode.*;
+import static com.example.appcenter_project.exception.ErrorCode.ROOMMATE_CHAT_ROOM_NOT_FOUND;
+
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+@Slf4j
+public class RoommateChattingRoomService {
+
+    private final RoommateChattingRoomRepository roommateChattingRoomRepository;
+    private final RoommateBoardRepository roommateBoardRepository;
+    private final UserRepository userRepository;
+
+    //채팅방 생성
+    @Transactional
+    public Long createChatRoom(Long guestId, Long roommateBoardId) {
+        // 게시글 조회
+        RoommateBoard roommateBoard = roommateBoardRepository.findById(roommateBoardId)
+                .orElseThrow(() -> new CustomException(ROOMMATE_BOARD_NOT_FOUND));
+
+        // host는 게시글 작성자
+        User host = roommateBoard.getUser();
+        User guest = userRepository.findById(guestId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 자기 자신과 채팅 방지
+        if (host.getId().equals(guest.getId())) {
+            throw new CustomException(ROOMMATE_CHAT_CANNOT_CHAT_WITH_SELF);
+        }
+
+        // 이미 채팅방이 있는지 확인
+        boolean exists = roommateChattingRoomRepository.existsByRoommateBoardAndGuest(roommateBoard, guest);
+        if (exists) {
+            throw new CustomException(DUPLICATE_CHAT_ROOM);
+        }
+
+        // 채팅방 생성
+        RoommateChattingRoom chattingRoom = RoommateChattingRoom.builder()
+                .roommateBoard(roommateBoard)
+                .host(host)
+                .guest(guest)
+                .hostChecklist(host.getRoommateCheckList())
+                .guestChecklist(guest.getRoommateCheckList())
+                .build();
+
+        roommateChattingRoomRepository.save(chattingRoom);
+        return chattingRoom.getId();
+    }
+
+    //채팅방 나가기
+    @Transactional
+    public void leaveChatRoom(Long guestId, Long chatRoomId) {
+        // 유저 조회
+        User guest = userRepository.findById(guestId)
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        // 채팅방 조회
+        RoommateChattingRoom chatRoom = roommateChattingRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ROOMMATE_CHAT_ROOM_NOT_FOUND));
+
+        // 채팅방의 게스트와 일치하는지 확인
+        if (!chatRoom.getGuest().getId().equals(guest.getId())) {
+            throw new CustomException(ROOMMATE_FORBIDDEN_ACCESS);
+        }
+
+        // 채팅방 삭제
+        roommateChattingRoomRepository.delete(chatRoom);
+    }
+
+    @Transactional(readOnly = true)
+    public List<ResponseRoommateChatRoomDto> findRoommateChatRoomListByUser(CustomUserDetails userDetails) {
+        User user = userRepository.findById(userDetails.getId())
+                .orElseThrow(() -> new CustomException(USER_NOT_FOUND));
+
+        List<RoommateChattingRoom> rooms = roommateChattingRoomRepository.findAllByHostOrGuest(user, user);
+
+        List<ResponseRoommateChatRoomDto> result = new ArrayList<>();
+        int index = 1;
+
+        for (RoommateChattingRoom room : rooms) {
+            // 익명 N 설정
+            String opponentNickname = "익명 " + index++;
+
+            // 마지막 메시지
+            Optional<RoommateChattingChat> lastChat = room.getChattingChatList().stream()
+                    .max(Comparator.comparing(RoommateChattingChat::getCreatedDate));
+
+            String lastMessage = lastChat.map(RoommateChattingChat::getContent).orElse("");
+            LocalDateTime lastMessageTime = lastChat.map(RoommateChattingChat::getCreatedDate).orElse(null);
+
+            // DTO 생성
+            result.add(ResponseRoommateChatRoomDto.builder()
+                    .chatRoomId(room.getId())
+                    .opponentNickname(opponentNickname)
+                    .lastMessage(lastMessage)
+                    .lastMessageTime(lastMessageTime)
+                    .build());
+        }
+
+        // 마지막 메시지 시간 기준 내림차순 정렬 (null은 맨 뒤)
+        result.sort(Comparator.comparing(ResponseRoommateChatRoomDto::getLastMessageTime,
+                Comparator.nullsLast(Comparator.reverseOrder())));
+
+        return result;
+    }
+
+    @Transactional(readOnly = true)
+    public RoommateCheckList getOpponentChecklist(Long userId, Long chatRoomId) {
+        RoommateChattingRoom chatRoom = roommateChattingRoomRepository.findById(chatRoomId)
+                .orElseThrow(() -> new CustomException(ROOMMATE_CHAT_ROOM_NOT_FOUND));
+
+        // 본인이 참여 중인지 검증
+        if (!chatRoom.getHost().getId().equals(userId) && !chatRoom.getGuest().getId().equals(userId)) {
+            throw new CustomException(ROOMMATE_FORBIDDEN_ACCESS);
+        }
+
+        // 상대방 체크리스트 반환
+        if (chatRoom.getHost().getId().equals(userId)) {
+            return chatRoom.getGuestChecklist(); // 상대는 guest
+        } else {
+            return chatRoom.getHostChecklist(); // 상대는 host
+        }
+    }
+
+
+
+
+}
+


### PR DESCRIPTION
### 관련이슈
#118 

### 구현한 기능
- 채팅방 생성 기능 (createChatRoom)
룸메이트 게시글을 기반으로 채팅방 생성
본인이 작성한 게시글에 채팅 요청 시 예외 처리
동일 사용자와 중복 채팅방 방지

- 채팅방 목록 조회 기능 (findRoommateChatRoomListByUser)
로그인한 사용자가 참여 중인 채팅방 목록을 반환
마지막 메시지 기준 최신순 정렬
상대방 닉네임은 익명 N 형식으로 마스킹 처리

-채팅방 나가기 기능 (leaveChatRoom)
사용자가 게스트일 경우에만 채팅방에서 나가기 가능
방 삭제 처리

-상대방 체크리스트 조회 기능 (getOpponentChecklist)
채팅방 ID와 사용자 ID를 기반으로 상대방 체크리스트 반환
host/guest 관계를 파악하여 상대방 checklist 구분

채팅방 참여자가 아닐 경우 예외 처리

### 사진
-채팅방 생성
<img width="1261" height="1273" alt="image" src="https://github.com/user-attachments/assets/77985828-dbda-4e29-ab11-1aad631ae82d" />

-상대방 체크리스트 조회
<img width="1325" height="1302" alt="image" src="https://github.com/user-attachments/assets/7cc31945-f748-4c45-8a66-980793414029" />

-채팅방 목록 조회 
<img width="1327" height="1289" alt="image" src="https://github.com/user-attachments/assets/f3cba88a-2ad5-467e-bb5f-3dc7d2c10243" />

-채팅방 나가기 기능
<img width="1105" height="876" alt="image" src="https://github.com/user-attachments/assets/91816043-4e2f-4740-9369-dec93279dbff" />
