### PR TITLE
fix(websocket): 웹소켓 연결 시 발생하는 CORS 오류 수정 #16

### DIFF
--- a/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
@@ -14,7 +14,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOrigins("http://localhost:5173", "https://inu-dormitory.inuappcenter.kr", "https://inu-dormitory-dev.inuappcenter.kr")
-                .setAllowedCredentials(true)
                 .withSockJS();
     }
 

--- a/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
@@ -12,9 +12,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // ws://localhost:8080/chat/inbox
-        registry.addEndpoint("/chat/inbox")
-                .setAllowedOriginPatterns("*");
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOrigins("http://localhost:5173", "https://inu-dormitory.inuappcenter.kr", "https://inu-dormitory-dev.inuappcenter.kr")
+                .setAllowedCredentials(true)
+                .withSockJS();
     }
 
     @Override


### PR DESCRIPTION
### 관련이슈
#16 

### 개요
프론트엔드에서 웹소켓 연결을 시도할 때 발생하는 CORS(Cross-Origin Resource Sharing) 정책 위반 오류를 해결

### 원인
웹소켓 연결 시 인증 정보(credentials)가 포함된 요청을 보낼 때, 브라우저의 보안 정책상 서버는 Access-Control-Allow-Origin 응답 헤더에 와일드카드(*)를 사용하면 안 되고, 요청을 보낸 출처(origin)를 명시적으로 지정해야 함
기존 WebSocketConfig.java의 STOMP 엔드포인트 설정에는 setAllowedOriginPatterns("*")가 사용됨 이 설정은 서버가 모든 출처를 허용한다는 의미의 와일드카드(*) 헤더를 응답하도록 하여, 결과적으로 브라우저의 CORS 보안 정책을 위반하게 됨

### 변경사항
- config/WebSocketConfig.java 파일 수정
 - registerStompEndpoints 메소드에서 기존의 
 - setAllowedOriginPatterns("*") 설정을 제거
 - setAllowedOrigins()를 사용하여 로컬 개발 환경(http://localhost:5173) 및 개발/운영 서버의 프론트엔드 주소를 명시적으로 허용하도록 변경
  - 프론트엔드에서 접속을 시도하는 엔드포인트(ws-stomp)와 일치하도록 백엔드 엔드포인트 경로를 수정