### PR TITLE
Jimin/roommate matching bug 18

### DIFF
--- a/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
@@ -14,7 +14,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOrigins("http://localhost:5173", "https://inu-dormitory.inuappcenter.kr", "https://inu-dormitory-dev.inuappcenter.kr")
-                .setAllowedCredentials(true)
                 .withSockJS();
     }
 

--- a/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
@@ -12,9 +12,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // ws://localhost:8080/chat/inbox
-        registry.addEndpoint("/chat/inbox")
-                .setAllowedOriginPatterns("*");
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOrigins("http://localhost:5173", "https://inu-dormitory.inuappcenter.kr", "https://inu-dormitory-dev.inuappcenter.kr")
+                .setAllowedCredentials(true)
+                .withSockJS();
     }
 
     @Override

--- a/src/main/java/com/example/appcenter_project/entity/user/User.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/User.java
@@ -60,28 +60,28 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "image_id")
     private Image image;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Tip> tipList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<GroupOrderLike> groupOrderLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TipLike> tipLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<GroupOrder> groupOrderList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", orphanRemoval = true)
+    @OneToMany(mappedBy = "user", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserGroupOrderChatRoom> userGroupOrderChatRoomList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private RoommateCheckList roommateCheckList;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private RoommateBoard roommateBoard;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private MyRoommate myRoommate;
 
 

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -31,7 +31,7 @@ public class RoommateMatchingService {
         User receiver = userRepository.findByStudentNumber(receiverStudentNumber)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
 
-        if (receiver.getRoommateBoard() != null) {
+        if (myRoommateRepository.findByUserId(receiver.getId()).isPresent()) {
             throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
         }
 
@@ -56,6 +56,7 @@ public class RoommateMatchingService {
     }
 
     // 매칭 수락
+    @Transactional
     public void acceptMatching(Long matchingId, Long userId) {
 
         User user = userRepository.findById(userId)
@@ -70,14 +71,13 @@ public class RoommateMatchingService {
             throw new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOR_USER);
         }
 
-
         // 이미 완료된 요청인지 확인
         if (matching.getStatus() != MatchingStatus.REQUEST) {
             throw new CustomException(ErrorCode.ROOMMATE_MATCHING_ALREADY_COMPLETED);
         }
 
         // 이미 매칭 완료된 사람인지 확인
-        if (user.getRoommateBoard() != null) {
+        if (myRoommateRepository.findByUserId(user.getId()).isPresent()) {
             throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
         }
 
@@ -102,6 +102,7 @@ public class RoommateMatchingService {
     }
 
     // 매칭 거절
+    @Transactional
     public void rejectMatching(Long matchingId) {
         RoommateMatching matching = roommateMatchingRepository.findById(matchingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOUND));


### PR DESCRIPTION
### 관련 이슈
#18 

### 구현내용
- `RoommateMatchingService` 로직 수정
    - `requestMatching`, `acceptMatching` 메서드에서 사용자의 매칭 상태를 확인할 때, `myRoommateRepository.findByUserId()`를 호출하여 `MyRoommate` 테이블에 데이터가 있는지 직접 확인하도록 수정했습니다. 이를 통해 정확한 매칭 상태를 판별할 수 있습니다.

- `User` 엔티티 연관 관계 수정 (N+1 문제 해결)
    - `User` 엔티티 내 모든 `@OneToOne`, `@OneToMany` 연관 관계에 `fetch = FetchType.LAZY` 속성을 명시적으로 추가했습니다.
    - 이를 통해 `User` 엔티티 조회 시 실제로 해당 연관 엔티티를 사용하는 시점까지 데이터베이스 조회를 지연시켜 불필요한 쿼리 발생을 막고 성능을 최적화했습니다.
    - 데이터 변경이 연관된 엔티티에 모두 반영되도록 `cascade = CascadeType.ALL` 옵션을 추가했습니다.