### PR TITLE
Jimin/unify image url logic 20

### DIFF
--- a/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
@@ -14,7 +14,6 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
     public void registerStompEndpoints(StompEndpointRegistry registry) {
         registry.addEndpoint("/ws-stomp")
                 .setAllowedOrigins("http://localhost:5173", "https://inu-dormitory.inuappcenter.kr", "https://inu-dormitory-dev.inuappcenter.kr")
-                .setAllowedCredentials(true)
                 .withSockJS();
     }
 

--- a/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
+++ b/src/main/java/com/example/appcenter_project/config/WebSocketConfig.java
@@ -12,9 +12,10 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void registerStompEndpoints(StompEndpointRegistry registry) {
-        // ws://localhost:8080/chat/inbox
-        registry.addEndpoint("/chat/inbox")
-                .setAllowedOriginPatterns("*");
+        registry.addEndpoint("/ws-stomp")
+                .setAllowedOrigins("http://localhost:5173", "https://inu-dormitory.inuappcenter.kr", "https://inu-dormitory-dev.inuappcenter.kr")
+                .setAllowedCredentials(true)
+                .withSockJS();
     }
 
     @Override

--- a/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateApiSpecification.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.RequestBody;
 
@@ -28,7 +29,8 @@ public interface MyRoommateApiSpecification {
             }
     )
     ResponseEntity<ResponseMyRoommateInfoDto> getMyRoommate(
-            @Parameter(hidden = true) CustomUserDetails userDetails
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(hidden = true) HttpServletRequest request
     );
 
     @Operation(

--- a/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/MyRoommateController.java
@@ -8,6 +8,7 @@ import com.example.appcenter_project.dto.response.roommate.ResponseRuleDto;
 import com.example.appcenter_project.security.CustomUserDetails;
 import com.example.appcenter_project.service.roommate.MyRoommateService;
 import com.example.appcenter_project.service.roommate.RoommateService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -20,9 +21,9 @@ public class MyRoommateController implements MyRoommateApiSpecification {
 
     private final MyRoommateService myRoommateService;
     @GetMapping("/informations")
-    public ResponseEntity<ResponseMyRoommateInfoDto> getMyRoommate(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public ResponseEntity<ResponseMyRoommateInfoDto> getMyRoommate(@AuthenticationPrincipal CustomUserDetails userDetails, HttpServletRequest request) {
         Long userId = userDetails.getId();
-        ResponseMyRoommateInfoDto response = myRoommateService.getMyRoommateInfo(userId);
+        ResponseMyRoommateInfoDto response = myRoommateService.getMyRoommateInfo(userId, request);
         return ResponseEntity.ok(response);
     }
 

--- a/src/main/java/com/example/appcenter_project/entity/user/User.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/User.java
@@ -60,28 +60,28 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "image_id")
     private Image image;
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Tip> tipList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<GroupOrderLike> groupOrderLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TipLike> tipLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<GroupOrder> groupOrderList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", orphanRemoval = true)
+    @OneToMany(mappedBy = "user", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserGroupOrderChatRoom> userGroupOrderChatRoomList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private RoommateCheckList roommateCheckList;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private RoommateBoard roommateBoard;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private MyRoommate myRoommate;
 
 

--- a/src/main/java/com/example/appcenter_project/service/roommate/MyRoommateService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/MyRoommateService.java
@@ -7,6 +7,8 @@ import com.example.appcenter_project.entity.user.User;
 import com.example.appcenter_project.exception.CustomException;
 import com.example.appcenter_project.exception.ErrorCode;
 import com.example.appcenter_project.repository.roommate.MyRoommateRepository;
+import com.example.appcenter_project.service.image.ImageService;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,9 +22,10 @@ import static com.example.appcenter_project.exception.ErrorCode.MY_ROOMMATE_NOT_
 public class MyRoommateService {
 
     private final MyRoommateRepository myRoommateRepository;
+    private final ImageService imageService;
 
     @Transactional(readOnly = true)
-    public ResponseMyRoommateInfoDto getMyRoommateInfo(Long userId){
+    public ResponseMyRoommateInfoDto getMyRoommateInfo(Long userId, HttpServletRequest request){
         MyRoommate myRoommate = myRoommateRepository.findByUserId(userId)
                 .orElseThrow(() -> new CustomException(MY_ROOMMATE_NOT_REGISTERED));
 
@@ -32,7 +35,7 @@ public class MyRoommateService {
                 .name(roommate.getName())
                 .dormType(roommate.getDormType() != null ? roommate.getDormType().name() : null)
                 .college(roommate.getCollege() != null ? roommate.getCollege().name() : null)
-                .imagePath(roommate.getImage() != null ? roommate.getImage().getFilePath() : null)
+                .imagePath(imageService.findUserImageUrlByUserId(roommate.getId(), request).getFileName())
                 .build();
     }
 

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -31,7 +31,7 @@ public class RoommateMatchingService {
         User receiver = userRepository.findByStudentNumber(receiverStudentNumber)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
 
-        if (receiver.getRoommateBoard() != null) {
+        if (myRoommateRepository.findByUserId(receiver.getId()).isPresent()) {
             throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
         }
 
@@ -56,6 +56,7 @@ public class RoommateMatchingService {
     }
 
     // 매칭 수락
+    @Transactional
     public void acceptMatching(Long matchingId, Long userId) {
 
         User user = userRepository.findById(userId)
@@ -70,14 +71,13 @@ public class RoommateMatchingService {
             throw new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOR_USER);
         }
 
-
         // 이미 완료된 요청인지 확인
         if (matching.getStatus() != MatchingStatus.REQUEST) {
             throw new CustomException(ErrorCode.ROOMMATE_MATCHING_ALREADY_COMPLETED);
         }
 
         // 이미 매칭 완료된 사람인지 확인
-        if (user.getRoommateBoard() != null) {
+        if (myRoommateRepository.findByUserId(user.getId()).isPresent()) {
             throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
         }
 
@@ -102,6 +102,7 @@ public class RoommateMatchingService {
     }
 
     // 매칭 거절
+    @Transactional
     public void rejectMatching(Long matchingId) {
         RoommateMatching matching = roommateMatchingRepository.findById(matchingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOUND));


### PR DESCRIPTION
### 관련 이슈
#20 

### 구현한 내용
1.  **`ImageService`에 공통 메서드 추가**:
    - 사용자 ID(`userId`)를 받아 해당 사용자의 프로필 사진 URL을 반환하는 `findUserImageUrlByUserId` 메서드를 `ImageService`에 새로 구현했습니다.
    - 이 메서드는 사용자가 별도의 프로필 사진을 설정하지 않은 경우, 기본 프로필 이미지의 URL을 반환하도록 처리합니다.

2.  **`MyRoommateService` 로직 수정**:
    - `getMyRoommateInfo` 메서드 내부에서 프로필 사진 경로를 직접 다루던 기존 로직을 제거했습니다.
    - 대신, 새로 추가된 `imageService.findUserImageUrlByUserId()`를 호출하여 룸메이트의 프로필 사진 URL을 가져오도록 수정했습니다.
