### PR TITLE
Jimin/roommate similar list like count 41

### DIFF
--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateApiSpecification.java
@@ -105,5 +105,35 @@ public interface RoommateApiSpecification {
             RequestRoommateFormDto requestDto
     );
 
+    @Operation(
+            summary = "룸메이트 게시글 좋아요",
+            description = "특정 게시글에 좋아요를 추가합니다. 이미 좋아요를 누른 경우 에러가 발생합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "좋아요 성공, 현재 좋아요 개수 반환",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 유저 또는 게시글이 존재하지 않음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND)", content = @Content),
+                    @ApiResponse(responseCode = "401", description = "이미 좋아요를 누른 유저 (ALREADY_ROOMMATE_BOARD_LIKE_USER)", content = @Content)
+            }
+    )
+    ResponseEntity<Integer> plusLike(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "좋아요를 누를 게시글 ID", example = "1")
+            @PathVariable Long boardId
+    );
+
+    @Operation(
+            summary = "룸메이트 게시글 좋아요 취소",
+            description = "특정 게시글의 좋아요를 취소합니다. 좋아요를 누르지 않은 경우 에러가 발생합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "좋아요 취소 성공, 현재 좋아요 개수 반환",
+                            content = @Content(mediaType = "application/json", schema = @Schema(implementation = Integer.class))),
+                    @ApiResponse(responseCode = "404", description = "해당 유저, 게시글 또는 좋아요 정보가 없음 (ROOMMATE_USER_NOT_FOUND, ROOMMATE_BOARD_NOT_FOUND, ROOMMATE_BOARD_LIKE_NOT_FOUND)", content = @Content)
+            }
+    )
+    ResponseEntity<Integer> minusLike(
+            @Parameter(hidden = true) CustomUserDetails userDetails,
+            @Parameter(description = "좋아요 취소할 게시글 ID", example = "1")
+            @PathVariable Long boardId
+    );
 
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateController.java
@@ -57,4 +57,23 @@ public class RoommateController implements RoommateApiSpecification{
         ResponseRoommatePostDto updated = roommateService.updateRoommateChecklistAndBoard(requestDto, userId);
         return ResponseEntity.ok(updated);
     }
+
+    @PostMapping("/{boardId}/like")
+    public ResponseEntity<Integer> plusLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long boardId
+    ) {
+        Integer likeCount = roommateService.likePlusRoommateBoard(userDetails.getId(), boardId);
+        return ResponseEntity.ok(likeCount);
+    }
+
+    @DeleteMapping("/{boardId}/like")
+    public ResponseEntity<Integer> minusLike(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long boardId
+    ) {
+        Integer likeCount = roommateService.likeMinusRoommateBoard(userDetails.getId(), boardId);
+        return ResponseEntity.ok(likeCount);
+    }
+
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingApiSpecification.java
@@ -1,6 +1,8 @@
 package com.example.appcenter_project.controller.roommate;
 
 import com.example.appcenter_project.dto.request.roommate.RequestMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseReceivedRoommateMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
 import com.example.appcenter_project.security.CustomUserDetails;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -61,5 +63,27 @@ public interface RoommateMatchingApiSpecification {
             @Parameter(description = "매칭 ID", example = "1") @PathVariable Long matchingId
     );
 
+    @Operation(
+            summary = "나에게 온 룸메이트 매칭 요청 리스트 조회",
+            description = "나에게 요청된 모든 룸메이트 매칭 요청(수락 대기 상태) 리스트를 조회합니다.",
+            responses = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "매칭 요청 리스트 조회 성공",
+                            content = @Content(
+                                    mediaType = "application/json",
+                                    schema = @Schema(implementation = ResponseReceivedRoommateMatchingDto.class) // ← 여기!
+                            )
+                    ),
+                    @ApiResponse(
+                            responseCode = "404",
+                            description = "사용자를 찾을 수 없습니다. (ROOMMATE_USER_NOT_FOUND)",
+                            content = @Content
+                    )
+            }
+    )
+    ResponseEntity<?> getReceivedMatchings(
+            @Parameter(hidden = true) @AuthenticationPrincipal CustomUserDetails userDetails
+    );
 
 }

--- a/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
+++ b/src/main/java/com/example/appcenter_project/controller/roommate/RoommateMatchingController.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.controller.roommate;
 
 import com.example.appcenter_project.dto.request.roommate.RequestMatchingDto;
+import com.example.appcenter_project.dto.response.roommate.ResponseReceivedRoommateMatchingDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommatePostDto;
 import com.example.appcenter_project.entity.user.User;
@@ -11,6 +12,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/roommate-matching")
@@ -43,6 +46,16 @@ public class RoommateMatchingController implements RoommateMatchingApiSpecificat
         roommateMatchingService.rejectMatching(matchingId);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/received")
+    public ResponseEntity<List<ResponseReceivedRoommateMatchingDto>> getReceivedMatchings(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long receiverId = userDetails.getId();
+        List<ResponseReceivedRoommateMatchingDto> responseDtos = roommateMatchingService.getReceivedMatchings(receiverId);
+        return ResponseEntity.ok(responseDtos);
+    }
+
 
 }
 

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseReceivedRoommateMatchingDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseReceivedRoommateMatchingDto.java
@@ -1,0 +1,21 @@
+package com.example.appcenter_project.dto.response.roommate;
+
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class ResponseReceivedRoommateMatchingDto {
+    private Long matchingId;
+    private Long senderId;
+    private String senderName;
+    private MatchingStatus status;
+
+    @Builder
+    public ResponseReceivedRoommateMatchingDto(Long matchingId, Long senderId, String senderName, MatchingStatus status) {
+        this.matchingId = matchingId;
+        this.senderId = senderId;
+        this.senderName = senderName;
+        this.status = status;
+    }
+}

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
@@ -30,6 +30,7 @@ public class ResponseRoommatePostDto {
     private BedTimeType bedTime;
     private CleanlinessType arrangement;
     private String comment;
+    private int roommateBoardLike;
 
     public static ResponseRoommatePostDto entityToDto(RoommateBoard board) {
         RoommateCheckList cl = board.getRoommateCheckList();
@@ -50,6 +51,7 @@ public class ResponseRoommatePostDto {
                 .bedTime(cl.getBedTime())
                 .arrangement(cl.getArrangement())
                 .comment(cl.getComment())
+                .roommateBoardLike(board.getRoommateBoardLike())
                 .build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
@@ -25,6 +25,7 @@ public class ResponseRoommateSimilarityDto {
     private BedTimeType bedTime;
     private CleanlinessType arrangement;
     private String comment;
+    private int roommateBoardLike;
 
     private Integer similarityPercentage;
 }

--- a/src/main/java/com/example/appcenter_project/entity/like/RoommateBoardLike.java
+++ b/src/main/java/com/example/appcenter_project/entity/like/RoommateBoardLike.java
@@ -1,0 +1,34 @@
+package com.example.appcenter_project.entity.like;
+
+import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.entity.roommate.RoommateBoard;
+import com.example.appcenter_project.entity.user.User;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@Getter
+public class RoommateBoardLike extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    // 좋아요 누른 룸메이트 게시글
+    @ManyToOne
+    @JoinColumn(name = "roommate_board_id")
+    private RoommateBoard roommateBoard;
+
+    @Builder
+    public RoommateBoardLike(User user, RoommateBoard roommateBoard) {
+        this.user = user;
+        this.roommateBoard = roommateBoard;
+    }
+}

--- a/src/main/java/com/example/appcenter_project/entity/roommate/RoommateBoard.java
+++ b/src/main/java/com/example/appcenter_project/entity/roommate/RoommateBoard.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.entity.roommate;
 
 import com.example.appcenter_project.entity.BaseTimeEntity;
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
 import com.example.appcenter_project.entity.user.User;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
@@ -9,6 +10,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.lang.reflect.Member;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Getter
@@ -29,7 +32,12 @@ public class RoommateBoard extends BaseTimeEntity {
     @JoinColumn(name = "roommate_checklist_id")
     private RoommateCheckList roommateCheckList;
 
-    private int roommateBoardLike;
+    @OneToMany(mappedBy = "roommateBoard", orphanRemoval = true, fetch = FetchType.EAGER)
+    private List<RoommateBoardLike> roommateBoardLikeList = new ArrayList<>();
+
+    @Column(nullable = false)
+    private int roommateBoardLike = 0;
+
 
     public Integer plusLike(){
         this.roommateBoardLike +=1;
@@ -52,5 +60,6 @@ public class RoommateBoard extends BaseTimeEntity {
     public void updateTitle(String title){
         this.title = title;
     }
+
 
 }

--- a/src/main/java/com/example/appcenter_project/entity/user/User.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/User.java
@@ -61,29 +61,44 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "image_id")
     private Image image;
 
-    @OneToMany(mappedBy = "user")
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "time_table_image_id")
+    private Image timeTableImage;
+
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<Tip> tipList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<GroupOrderLike> groupOrderLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<TipLike> tipLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user")
+    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<GroupOrder> groupOrderList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", orphanRemoval = true)
+    @OneToMany(mappedBy = "user", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private List<UserGroupOrderChatRoom> userGroupOrderChatRoomList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private RoommateCheckList roommateCheckList;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private RoommateBoard roommateBoard;
 
-    @OneToOne(mappedBy = "user")
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
     private MyRoommate myRoommate;
+
+    @OneToMany(mappedBy = "user")
+    private List<RoommateBoardLike> roommateBoardLikeList = new ArrayList<>();
+
+    public void addRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
+        this.roommateBoardLikeList.add(roommateBoardLike);
+    }
+
+    public void removeRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
+        this.roommateBoardLikeList.remove(roommateBoardLike);
+    }
 
 
     @Builder
@@ -99,13 +114,21 @@ public class User extends BaseTimeEntity {
 
     public void update(RequestUserDto requestUserDto) {
         this.name = requestUserDto.getName();
-        this.dormType = DormType.valueOf(requestUserDto.getDormType());
-        this.college = College.valueOf(requestUserDto.getCollege());
+        this.dormType = DormType.from(requestUserDto.getDormType());
+        this.college = College.from(requestUserDto.getCollege());
         this.penalty = requestUserDto.getPenalty();
     }
 
     public void updateImage(Image image) {
         this.image =image;
+    }
+
+    public void updateTimeTableImage(Image timeTableImage) {
+        this.timeTableImage = timeTableImage;
+    }
+
+    public void removeTimeTableImage() {
+        this.timeTableImage = null;
     }
 
     public void addTip(Tip tip) {
@@ -135,18 +158,6 @@ public class User extends BaseTimeEntity {
     public void removeGroupOrderLike(GroupOrderLike groupOrderLike) {
         this.groupOrderLikeList.remove(groupOrderLike);
     }
-
-    @OneToMany(mappedBy = "user")
-    private List<RoommateBoardLike> roommateBoardLikeList = new ArrayList<>();
-
-    public void addRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
-        this.roommateBoardLikeList.add(roommateBoardLike);
-    }
-
-    public void removeRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
-        this.roommateBoardLikeList.remove(roommateBoardLike);
-    }
-
 
     public void addSearchKeyword(String keyword) {
         if (searchLog == null) {

--- a/src/main/java/com/example/appcenter_project/entity/user/User.java
+++ b/src/main/java/com/example/appcenter_project/entity/user/User.java
@@ -7,6 +7,7 @@ import com.example.appcenter_project.entity.Image;
 import com.example.appcenter_project.entity.groupOrder.GroupOrder;
 import com.example.appcenter_project.entity.groupOrder.UserGroupOrderChatRoom;
 import com.example.appcenter_project.entity.like.GroupOrderLike;
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
 import com.example.appcenter_project.entity.like.TipLike;
 import com.example.appcenter_project.entity.roommate.RoommateBoard;
 import com.example.appcenter_project.entity.roommate.RoommateCheckList;
@@ -60,32 +61,28 @@ public class User extends BaseTimeEntity {
     @JoinColumn(name = "image_id")
     private Image image;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "time_table_image_id")
-    private Image timeTableImage;
-
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user")
     private List<Tip> tipList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user")
     private List<GroupOrderLike> groupOrderLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user")
     private List<TipLike> tipLikeList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user")
     private List<GroupOrder> groupOrderList = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", orphanRemoval = true, fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "user", orphanRemoval = true)
     private List<UserGroupOrderChatRoom> userGroupOrderChatRoomList = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user")
     private RoommateCheckList roommateCheckList;
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user")
     private RoommateBoard roommateBoard;
 
-    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user")
     private MyRoommate myRoommate;
 
 
@@ -102,21 +99,13 @@ public class User extends BaseTimeEntity {
 
     public void update(RequestUserDto requestUserDto) {
         this.name = requestUserDto.getName();
-        this.dormType = DormType.from(requestUserDto.getDormType());
-        this.college = College.from(requestUserDto.getCollege());
+        this.dormType = DormType.valueOf(requestUserDto.getDormType());
+        this.college = College.valueOf(requestUserDto.getCollege());
         this.penalty = requestUserDto.getPenalty();
     }
 
     public void updateImage(Image image) {
         this.image =image;
-    }
-
-    public void updateTimeTableImage(Image timeTableImage) {
-        this.timeTableImage = timeTableImage;
-    }
-
-    public void removeTimeTableImage() {
-        this.timeTableImage = null;
     }
 
     public void addTip(Tip tip) {
@@ -146,6 +135,18 @@ public class User extends BaseTimeEntity {
     public void removeGroupOrderLike(GroupOrderLike groupOrderLike) {
         this.groupOrderLikeList.remove(groupOrderLike);
     }
+
+    @OneToMany(mappedBy = "user")
+    private List<RoommateBoardLike> roommateBoardLikeList = new ArrayList<>();
+
+    public void addRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
+        this.roommateBoardLikeList.add(roommateBoardLike);
+    }
+
+    public void removeRoommateBoardLike(RoommateBoardLike roommateBoardLike) {
+        this.roommateBoardLikeList.remove(roommateBoardLike);
+    }
+
 
     public void addSearchKeyword(String keyword) {
         if (searchLog == null) {

--- a/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
+++ b/src/main/java/com/example/appcenter_project/exception/ErrorCode.java
@@ -66,6 +66,10 @@ public enum ErrorCode {
     ROOMMATE_UPDATE_NOT_ALLOWED(FORBIDDEN, 7007, "[Roommate] 수정 권한이 없습니다."),
     ROOMMATE_CHECKLIST_UPDATE_FAILED(BAD_REQUEST, 7008, "[Roommate] 체크리스트 수정에 실패했습니다."),
 
+    // ROOMMATE_BOARD_LIKE
+    ROOMMATE_BOARD_LIKE_NOT_FOUND(NOT_FOUND, 7501, "[RoommateBoard] 좋아요 정보를 찾을 수 없습니다."),
+    ALREADY_ROOMMATE_BOARD_LIKE_USER(UNAUTHORIZED, 7502, "[RoommateBoard] 이미 해당 게시글에 좋아요를 누른 유저입니다."),
+
     // ROOMMATE_MATCHING
     ROOMMATE_MATCHING_ALREADY_REQUESTED(CONFLICT, 8101, "[RoommateMatching] 이미 해당 사용자에게 매칭 요청을 보냈습니다."),
     ROOMMATE_MATCHING_NOT_FOUND(NOT_FOUND, 8102, "[RoommateMatching] 해당 매칭 요청을 찾을 수 없습니다."),

--- a/src/main/java/com/example/appcenter_project/repository/like/RoommateBoardLikeRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/like/RoommateBoardLikeRepository.java
@@ -1,0 +1,13 @@
+package com.example.appcenter_project.repository.like;
+
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
+import com.example.appcenter_project.entity.roommate.RoommateBoard;
+import com.example.appcenter_project.entity.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoommateBoardLikeRepository extends JpaRepository<RoommateBoardLike, Long> {
+    boolean existsByUserAndRoommateBoard(User user, RoommateBoard roommateBoard);
+    Optional<RoommateBoardLike> findByUserAndRoommateBoard(User user, RoommateBoard roommateBoard);
+}

--- a/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
+++ b/src/main/java/com/example/appcenter_project/repository/roommate/RoommateMatchingRepository.java
@@ -3,10 +3,17 @@ package com.example.appcenter_project.repository.roommate;
 
 import com.example.appcenter_project.entity.roommate.RoommateMatching;
 import com.example.appcenter_project.entity.user.User;
+import com.example.appcenter_project.enums.roommate.MatchingStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface RoommateMatchingRepository extends JpaRepository<RoommateMatching, Long> {
 
     boolean existsBySenderAndReceiver(User sender, User receiver);
+    List<RoommateMatching> findAllByReceiverAndStatus(User receiver, MatchingStatus status);
+    boolean existsBySenderAndStatus(User sender, MatchingStatus status);
+    boolean existsByReceiverAndStatus(User receiver, MatchingStatus status);
+
 
 }

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateMatchingService.java
@@ -1,5 +1,6 @@
 package com.example.appcenter_project.service.roommate;
 
+import com.example.appcenter_project.dto.response.roommate.ResponseReceivedRoommateMatchingDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateMatchingDto;
 import com.example.appcenter_project.entity.roommate.MyRoommate;
 import com.example.appcenter_project.entity.roommate.RoommateMatching;
@@ -13,6 +14,8 @@ import com.example.appcenter_project.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -31,7 +34,12 @@ public class RoommateMatchingService {
         User receiver = userRepository.findByStudentNumber(receiverStudentNumber)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
 
-        if (myRoommateRepository.findByUserId(receiver.getId()).isPresent()) {
+        // "이미 매칭된 사람" 체크 기준 개선!
+        boolean receiverAlreadyMatched =
+                roommateMatchingRepository.existsBySenderAndStatus(receiver, MatchingStatus.COMPLETED) ||
+                        roommateMatchingRepository.existsByReceiverAndStatus(receiver, MatchingStatus.COMPLETED);
+
+        if (receiverAlreadyMatched) {
             throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
         }
 
@@ -56,7 +64,6 @@ public class RoommateMatchingService {
     }
 
     // 매칭 수락
-    @Transactional
     public void acceptMatching(Long matchingId, Long userId) {
 
         User user = userRepository.findById(userId)
@@ -64,7 +71,6 @@ public class RoommateMatchingService {
 
         RoommateMatching matching = roommateMatchingRepository.findById(matchingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOUND));
-
 
         // 매칭 요청의 수신자가 현재 로그인한 사용자인지 확인
         if (!matching.getReceiver().getId().equals(user.getId())) {
@@ -76,8 +82,12 @@ public class RoommateMatchingService {
             throw new CustomException(ErrorCode.ROOMMATE_MATCHING_ALREADY_COMPLETED);
         }
 
-        // 이미 매칭 완료된 사람인지 확인
-        if (myRoommateRepository.findByUserId(user.getId()).isPresent()) {
+        // "이미 매칭된 사람" 체크 기준 개선!
+        boolean userAlreadyMatched =
+                roommateMatchingRepository.existsBySenderAndStatus(user, MatchingStatus.COMPLETED) ||
+                        roommateMatchingRepository.existsByReceiverAndStatus(user, MatchingStatus.COMPLETED);
+
+        if (userAlreadyMatched) {
             throw new CustomException(ErrorCode.ROOMMATE_ALREADY_MATCHED);
         }
 
@@ -102,7 +112,6 @@ public class RoommateMatchingService {
     }
 
     // 매칭 거절
-    @Transactional
     public void rejectMatching(Long matchingId) {
         RoommateMatching matching = roommateMatchingRepository.findById(matchingId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_MATCHING_NOT_FOUND));
@@ -113,5 +122,24 @@ public class RoommateMatchingService {
 
         matching.fail();
     }
+
+    // 매칭조회
+    @Transactional(readOnly = true)
+    public List<ResponseReceivedRoommateMatchingDto> getReceivedMatchings(Long receiverId) {
+        User receiver = userRepository.findById(receiverId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
+
+        List<RoommateMatching> matchings = roommateMatchingRepository.findAllByReceiverAndStatus(receiver, MatchingStatus.REQUEST);
+
+        return matchings.stream()
+                .map(matching -> ResponseReceivedRoommateMatchingDto.builder()
+                        .matchingId(matching.getId())
+                        .senderId(matching.getSender().getId())
+                        .senderName(matching.getSender().getName())
+                        .status(matching.getStatus())
+                        .build())
+                .toList();
+    }
+
 
 }

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
@@ -192,6 +192,7 @@ public class RoommateService {
                             .arrangement(cl.getArrangement())
                             .comment(cl.getComment())
                             .similarityPercentage(entry.getValue())
+                            .roommateBoardLike(entry.getKey().getRoommateBoardLike())
                             .build();
                 })
                 .toList();

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
@@ -3,23 +3,23 @@ package com.example.appcenter_project.service.roommate;
 import com.example.appcenter_project.dto.request.roommate.RequestRoommateFormDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommatePostDto;
 import com.example.appcenter_project.dto.response.roommate.ResponseRoommateSimilarityDto;
+import com.example.appcenter_project.entity.like.RoommateBoardLike;
 import com.example.appcenter_project.entity.roommate.RoommateBoard;
 import com.example.appcenter_project.entity.roommate.RoommateCheckList;
 import com.example.appcenter_project.entity.user.User;
 import com.example.appcenter_project.exception.CustomException;
 import com.example.appcenter_project.exception.ErrorCode;
+import com.example.appcenter_project.repository.like.RoommateBoardLikeRepository;
 import com.example.appcenter_project.repository.roommate.RoommateBoardRepository;
 import com.example.appcenter_project.repository.roommate.RoommateCheckListRepository;
 import com.example.appcenter_project.repository.user.UserRepository;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class RoommateService {
@@ -27,12 +27,10 @@ public class RoommateService {
     private final UserRepository userRepository;
     private final RoommateCheckListRepository roommateCheckListRepository;
     private final RoommateBoardRepository roommateBoardRepository;
+    private final RoommateBoardLikeRepository roommateBoardLikeRepository;
 
     @Transactional
     public ResponseRoommatePostDto createRoommateCheckListandBoard(RequestRoommateFormDto requestDto, Long userId) {
-
-        log.info("createRoommateCheckListandBoard title: {}, userId: {}", requestDto.getTitle(), userId);
-
         // 1. 유저 확인
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
@@ -115,6 +113,7 @@ public class RoommateService {
                             .bedTime(cl.getBedTime())
                             .arrangement(cl.getArrangement())
                             .comment(cl.getComment())
+                            .roommateBoardLike(board.getRoommateBoardLike())
                             .build(); //dto하나가 만들어짐
                 })
                 .toList(); //만든 dto들을 모아서 리스트로 뭉쳐줌
@@ -219,6 +218,64 @@ public class RoommateService {
         }
 
         return ResponseRoommatePostDto.entityToDto(board);
+    }
+
+    // 좋아요 추가 (Like)
+    @Transactional
+    public Integer likePlusRoommateBoard(Long userId, Long boardId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
+        RoommateBoard board = roommateBoardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_BOARD_NOT_FOUND));
+
+        // 이미 좋아요 누른 경우 예외처리
+        if (roommateBoardLikeRepository.existsByUserAndRoommateBoard(user, board)) {
+            throw new CustomException(ErrorCode.ALREADY_ROOMMATE_BOARD_LIKE_USER);
+        }
+
+        RoommateBoardLike roommateBoardLike = RoommateBoardLike.builder()
+                .user(user)
+                .roommateBoard(board)
+                .build();
+
+        roommateBoardLikeRepository.save(roommateBoardLike);
+
+        // user에 좋아요 정보 추가 (양방향 연관관계 유지 시)
+        user.addRoommateBoardLike(roommateBoardLike);
+
+        // board에 좋아요 정보 추가
+        board.getRoommateBoardLikeList().add(roommateBoardLike);
+
+        // 좋아요 카운트 증가
+        return board.plusLike();
+    }
+
+    // 좋아요 취소 (Unlike)
+    @Transactional
+    public Integer likeMinusRoommateBoard(Long userId, Long boardId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_USER_NOT_FOUND));
+        RoommateBoard board = roommateBoardRepository.findById(boardId)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_BOARD_NOT_FOUND));
+
+        if (!roommateBoardLikeRepository.existsByUserAndRoommateBoard(user, board)) {
+            throw new CustomException(ErrorCode.ROOMMATE_BOARD_LIKE_NOT_FOUND);
+        }
+
+        RoommateBoardLike roommateBoardLike = roommateBoardLikeRepository.findByUserAndRoommateBoard(user, board)
+                .orElseThrow(() -> new CustomException(ErrorCode.ROOMMATE_BOARD_LIKE_NOT_FOUND));
+
+        // user에서 좋아요 정보 제거
+        user.removeRoommateBoardLike(roommateBoardLike);
+
+        // board에서 좋아요 정보 제거
+        board.getRoommateBoardLikeList().remove(roommateBoardLike);
+
+        // 좋아요 DB에서 삭제
+        roommateBoardLikeRepository.delete(roommateBoardLike);
+
+        // 좋아요 카운트 감소
+        return board.minusLike();
     }
 
 


### PR DESCRIPTION
### 관련 이슈
#41 

### 구현한 기능
- 유사한 룸메이트 게시글 리스트(`/roommates/similar`) 응답에서 각 게시글의 좋아요 개수(roommateBoardLike)를 반환하도록 기능을 추가했습니다.
- `ResponseRoommateSimilarityDto`에 `roommateBoardLike` 필드를 추가하고, 서비스 레이어에서 해당 값이 포함되도록 매핑 로직을 수정했습니다.
- 프론트엔드에서 유사 게시글 리스트에 좋아요 수를 바로 표시할 수 있습니다.

