### PR TITLE
Jimin/roommate board dto userinfo 43

### DIFF
--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommatePostDto.java
@@ -1,6 +1,7 @@
 package com.example.appcenter_project.dto.response.roommate;
 
 import com.example.appcenter_project.entity.roommate.RoommateCheckList;
+import com.example.appcenter_project.entity.user.User;
 import com.example.appcenter_project.enums.roommate.*;
 import com.example.appcenter_project.enums.user.College;
 import com.example.appcenter_project.enums.user.DormType;
@@ -9,6 +10,7 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.util.Set;
 
 @Getter
@@ -31,9 +33,13 @@ public class ResponseRoommatePostDto {
     private CleanlinessType arrangement;
     private String comment;
     private int roommateBoardLike;
+    private Long userId;
+    private String userName;
+    private LocalDateTime createdDate;
 
     public static ResponseRoommatePostDto entityToDto(RoommateBoard board) {
         RoommateCheckList cl = board.getRoommateCheckList();
+        User user = board.getUser();
 
         return ResponseRoommatePostDto.builder()
                 .boardId(board.getId())
@@ -52,6 +58,9 @@ public class ResponseRoommatePostDto {
                 .arrangement(cl.getArrangement())
                 .comment(cl.getComment())
                 .roommateBoardLike(board.getRoommateBoardLike())
+                .userId(user.getId())
+                .userName(user.getName())
+                .createdDate(board.getCreatedDate())
                 .build();
     }
 }

--- a/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
+++ b/src/main/java/com/example/appcenter_project/dto/response/roommate/ResponseRoommateSimilarityDto.java
@@ -7,6 +7,8 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
+
 @Getter
 @Builder
 @AllArgsConstructor
@@ -25,7 +27,10 @@ public class ResponseRoommateSimilarityDto {
     private BedTimeType bedTime;
     private CleanlinessType arrangement;
     private String comment;
-    private int roommateBoardLike;
+    private Long userId;
+    private String userName;
+    private LocalDateTime createdDate;
 
+    private int roommateBoardLike;
     private Integer similarityPercentage;
 }

--- a/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
+++ b/src/main/java/com/example/appcenter_project/service/roommate/RoommateService.java
@@ -83,6 +83,9 @@ public class RoommateService {
                 .bedTime(savedCheckList.getBedTime())
                 .arrangement(savedCheckList.getArrangement())
                 .comment(savedCheckList.getComment())
+                .userId(user.getId())
+                .userName(user.getName())
+                .createdDate(roommateBoard.getCreatedDate())
                 .build();
     }
 
@@ -97,6 +100,7 @@ public class RoommateService {
         return boards.stream() //게시글 목록을 하나 꺼내서 준비
                 .map(board -> { //꺼낸 게시글 하나를 꾸미기 시작
                     RoommateCheckList cl = board.getRoommateCheckList(); //룸메이트 보드에있는 체크리스트를 꺼냄
+                    User writer = board.getUser();
                     return ResponseRoommatePostDto.builder() //화면에 보여줄 정보를 담아줌
                             .boardId(board.getId())
                             .title(cl.getTitle())
@@ -114,6 +118,9 @@ public class RoommateService {
                             .arrangement(cl.getArrangement())
                             .comment(cl.getComment())
                             .roommateBoardLike(board.getRoommateBoardLike())
+                            .userId(writer.getId())
+                            .userName(writer.getName())
+                            .createdDate(board.getCreatedDate())
                             .build(); //dto하나가 만들어짐
                 })
                 .toList(); //만든 dto들을 모아서 리스트로 뭉쳐줌
@@ -175,7 +182,10 @@ public class RoommateService {
                     return e2.getKey().getCreatedDate().compareTo(e1.getKey().getCreatedDate()); // 유사도 같으면 최신순
                 })
                 .map(entry -> {
+                    RoommateBoard board = entry.getKey();
                     RoommateCheckList cl = entry.getKey().getRoommateCheckList();
+                    User writer = board.getUser();
+
                     return ResponseRoommateSimilarityDto.builder()
                             .boardId(entry.getKey().getId())
                             .title(cl.getTitle())
@@ -193,6 +203,9 @@ public class RoommateService {
                             .comment(cl.getComment())
                             .similarityPercentage(entry.getValue())
                             .roommateBoardLike(entry.getKey().getRoommateBoardLike())
+                            .userId(writer.getId())
+                            .userName(writer.getName())
+                            .createdDate(board.getCreatedDate())
                             .build();
                 })
                 .toList();


### PR DESCRIPTION
### 관련 이슈
#147 

### 구현한 기능
- ResponseRoommatePostDto에 userId(작성자 ID), userName(작성자 이름), createdDate(게시글 생성일시) 필드를 추가
- RoommateBoard → ResponseRoommatePostDto로 변환하는 entityToDto() 메서드 및 Service 로직에서 해당 정보가 포함되도록 수정
- 게시글 목록/상세 조회 시 작성자 정보와 작성일시가 함께 반환됨

### 관련 이미지
-체크리스트 작성
<img width="1117" height="1312" alt="image" src="https://github.com/user-attachments/assets/e5f7028e-9d32-4045-94d8-473c2951d34a" />

-최신순 조회
<img width="1131" height="1261" alt="image" src="https://github.com/user-attachments/assets/a6e05a52-2a08-4021-b0e3-086731c36637" />

-단일조회
<img width="1121" height="1101" alt="image" src="https://github.com/user-attachments/assets/e7c90d66-671c-40ef-9f68-4893acc1b915" />

-유사
<img width="1214" height="1182" alt="image" src="https://github.com/user-attachments/assets/50ff0ef5-3627-4486-82b7-611b634162fb" />
